### PR TITLE
Fix build on macos

### DIFF
--- a/src/pd.mi.plts_tilde/pd.mi.plts_tilde.cpp
+++ b/src/pd.mi.plts_tilde/pd.mi.plts_tilde.cpp
@@ -436,9 +436,15 @@ static t_int *myObj_perform(t_int *w)
         if (self->modulations.trigger_patched)
         {
             // calc sum of trigger input
-            double vectorsum = 0.0;
+            t_sample vectorsum = 0.0;
 #ifdef __APPLE__
+#if PD_FLOATSIZE == 32
+            vDSP_sve(trig_input + count, 1, &vectorsum, size);
+#elif PD_FLOATSIZE == 64
             vDSP_sveD(trig_input + count, 1, &vectorsum, size);
+#else // PD_FLOATSIZE
+#error Unexpected PD_FLOATSIZE
+#endif // PD_FLOATSIZE
 #else
             for (int i = 0; i < size; ++i)
                 vectorsum += trig_input[i + count];

--- a/src/pd.mi.plts_tilde/pd.mi.plts_tilde.cpp
+++ b/src/pd.mi.plts_tilde/pd.mi.plts_tilde.cpp
@@ -123,7 +123,7 @@ static void *myObj_new(t_symbol *s, int argc, t_atom *argv)
         
         if(self->sigvs < kBlockSize) {
             pd_error((t_object*)self,
-                         "sigvs can't be smaller than %d samples\n", kBlockSize);
+                         "sigvs can't be smaller than %zu samples\n", kBlockSize);
             delete self;
             self = NULL;
             return self;
@@ -467,7 +467,7 @@ static void myObj_dsp(t_myObj *self, t_signal **sp)
 
     if (sys_getblksize() < kBlockSize)
     {
-        pd_error((t_object *)self, "sigvs can't be smaller than %d samples, sorry!", kBlockSize);
+        pd_error((t_object *)self, "sigvs can't be smaller than %zu samples, sorry!", kBlockSize);
         return;
     }
 

--- a/src/pd.mi.tds_tilde/pd.mi.tds_tilde.cpp
+++ b/src/pd.mi.tds_tilde/pd.mi.tds_tilde.cpp
@@ -147,7 +147,7 @@ void *myObj_new(t_symbol *s, int argc, t_atom *argv)
         if (self->sigvs < kAudioBlockSize)
         {
             pd_error((t_object *)self,
-                     "sigvs can't be smaller than %d samples\n", kAudioBlockSize);
+                     "sigvs can't be smaller than %zu samples\n", kAudioBlockSize);
             delete self;
             self = NULL;
             return self;
@@ -343,7 +343,7 @@ void myObj_ratio(t_myObj *self, t_float m)
 void output_mode_setter(t_myObj *self, t_float m)
 {
     long _m = clamp((int)m, 0, 3);
-    verbose(3, "output mode %d", _m);
+    verbose(3, "output mode %ld", _m);
     self->output_mode = tides::OutputMode(_m);
     if (self->output_mode != self->previous_output_mode)
     {
@@ -520,7 +520,7 @@ void myObj_dsp(t_myObj *self, t_signal **sp)
 
     if (sys_getblksize() < kAudioBlockSize)
     {
-        pd_error((t_object *)self, "sigvs can't be smaller than %d samples, sorry!", kAudioBlockSize);
+        pd_error((t_object *)self, "sigvs can't be smaller than %zu samples, sorry!", kAudioBlockSize);
         return;
     }
     if (sys_getsr() != self->sr)


### PR DESCRIPTION
fixed types for pd_error ; using `z` and `l` where appropriate. 
handling the case where PD_FLOATSIZE is 32 or 64 and use the corresponding macos DSP routine.

This now builds fine with no errors on macos (x86) and Linux (armv7)